### PR TITLE
Pull 1000 commits from Github API vs 30 (default)

### DIFF
--- a/javascripts/guts.pogo
+++ b/javascripts/guts.pogo
@@ -37,7 +37,7 @@ $
   (repo) commits link =
     user slash repo = repo.replace r/.*github.com[\/:](.*?)(\.git)?$/ '$1'
     {
-      url = "https://api.github.com/repos/#(user slash repo)/commits"
+      url = "https://api.github.com/repos/#(user slash repo)/commits?per_page=1000"
       hash_tag = "##(user slash repo)"
     }
 


### PR DESCRIPTION
I did not test this locally but I tested the URL argument via a browser request and it does load more commits. @bleen did this on a Drupal project that pulled from the Git API and it worked for us.
