### PR TITLE
Fix paths for usage on localhost

### DIFF
--- a/javascripts/guts.pogo
+++ b/javascripts/guts.pogo
@@ -63,12 +63,12 @@ $
     source prefix = if (window.location.hostname == 'localhost')
       ''
     else
-      'https://dl.dropboxusercontent.com/u/362737/starlogs.net'
+      'https://dl.dropboxusercontent.com/u/362737/starlogs.net/'
 
     tag = $ '<audio>' (id: file name, loop: looped)
 
-    mp3 source = $ '<source>' (src: "#(source prefix)/assets/#(file name).mp3", type: 'audio/mp3')
-    ogg source = $ '<source>' (src: "#(source prefix)/assets/#(file name).ogg", type: 'audio/ogg')
+    mp3 source = $ '<source>' (src: "#(source prefix)assets/#(file name).mp3", type: 'audio/mp3')
+    ogg source = $ '<source>' (src: "#(source prefix)assets/#(file name).ogg", type: 'audio/ogg')
 
     tag.append(mp3 source).append(ogg source).appendTo($ 'body')
 

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -2,7 +2,7 @@
 
 @font-face {
   font-family: SWCrawlBody;
-  src: url('/assets/SWCrawlBody.ttf');
+  src: url('../assets/SWCrawlBody.ttf');
 }
 
 html {
@@ -10,7 +10,7 @@ html {
 }
 
 body {
-  background: black url('/assets/stars.jpg') no-repeat top center fixed;
+  background: black url('../assets/stars.jpg') no-repeat top center fixed;
   background-size: cover;
   font-family: SWCrawlBody;
   height: 100%;


### PR DESCRIPTION
The StarLogs page was not able to find any assets when run on localhost (font, background, or audio). This should fix that, so it will work fully. In addition, it uses relative paths in the stylesheet, so it should work properly even if it's in a subdirectory in a website (http://www.example.com/starlogs/).
