### PR TITLE
Format messages more like the Star Wars opening crawl

### DIFF
--- a/javascripts/guts.pogo
+++ b/javascripts/guts.pogo
@@ -18,7 +18,12 @@ $
           crawl (messages)
         (delay())
       else
-        $ '.plane'.append ($('<div>', class: 'content').text (messages.0))
+        paragraphs = messages.0.split("\n\n")
+        subject = paragraphs.0
+        paragraphs := ['<p>' + paragraph + '</p>' , where: paragraph <- paragraphs , paragraph != subject]
+        body = '<div class="body">' + paragraphs.join("\n\n") + '</div>'
+        data = '<h3>' + subject + '</h3>' + body
+        $ '.plane'.append ($('<div>', class: 'content').html (data))
         set timeout
           crawl (messages.slice(counter))
         (delay())

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -76,6 +76,15 @@ body {
   opacity: 0;
   @include animation(crawling 25s linear);
 
+  h3 {
+      text-align: center;
+      font-size: 48px;
+      text-transform: uppercase;
+  }
+
+  div.body {
+      text-align: justify;
+  }
 }
 
 .paused {
@@ -93,4 +102,3 @@ body {
     top: 0%;
   }
 }
-


### PR DESCRIPTION
The subject line is all caps, centered.

Body text is justified.

When looking at more verbose commit logs, this simulates the Star Wars
experience fairly well, my limited testing found.

Subject-only commit messages still look okay (if a bit shouty).

(This is an improvement on an early approach that you may remember - it got reverted due to making single-line commit messages look ugly.

I have a project whose logs I want to read through for nostalgia's sake, so I decided to try hacking on this a bit more, and thought you might be interested in the result.)
